### PR TITLE
Added universe argument to Poller.send_dmx

### DIFF
--- a/src/artnet/daemon.py
+++ b/src/artnet/daemon.py
@@ -59,8 +59,8 @@ class Poller(threading.Thread):
 		if(p.opcode == OPCODES['OpPoll']):
 			self.send_poll_reply(p)
 	
-	def send_dmx(self, frame):
-		p = packet.DmxPacket(frame)
+	def send_dmx(self, frame, universe=0):
+		p = packet.DmxPacket(frame, universe=universe)
 		self.sock.sendto(p.encode(), (self.address, STANDARD_PORT))
 	
 	def send_poll(self):


### PR DESCRIPTION
I need a way to address several universes - all the components are in place but I couldn't find a way to pass the universe index information to the DMX frame so I added that universe optional arg, defaulting to universe '0'.

By the way, your project has been a tremendous help and inspiration, thank you !