### PR TITLE
Using multiple universes

### DIFF
--- a/src/artnet/daemon.py
+++ b/src/artnet/daemon.py
@@ -59,8 +59,8 @@ class Poller(threading.Thread):
 		if(p.opcode == OPCODES['OpPoll']):
 			self.send_poll_reply(p)
 	
-	def send_dmx(self, frame):
-		p = packet.DmxPacket(frame)
+	def send_dmx(self, frame, universe=0):
+		p = packet.DmxPacket(frame, universe=universe)
 		self.sock.sendto(p.encode(), (self.address, STANDARD_PORT))
 	
 	def send_poll(self):

--- a/src/artnet/packet.py
+++ b/src/artnet/packet.py
@@ -86,7 +86,7 @@ class DmxPacket(ArtNetPacket):
 		('protocol_version', 'uintbe:16'),
 		('sequence', 'int:8'),
 		('physical', 'int:8'),
-		('universe', 'uintbe:16'),
+		('universe', 'uintle:16'),
 		('length', 'uintbe:16'),
 		('framedata', 'bytes:512')
 	)


### PR DESCRIPTION
Here the second change I needed to make in order to address multiple universes : 
on the machines I have tested (Windows 8 asus laptop, Mac mini running windows), universe 1 ended up as 256, universe 2 as 512 etc. in the UDP frame as debugged in WireShark.

It seems to boild down to an endianness issue.
Did you ever use multiple universes and not see that problem ?

Again, thank you for sharing.